### PR TITLE
ci(release): set node v.18 as input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: Parsimotion/public-workflows/.github/workflows/release.yml@main
     with:
       prereleaseTag: ${{ inputs.prereleaseTag }}
-      node-version: "8"
+      node-version: "18"
       build-output-dir: "lib"  # Directorio de salida del build en este proyecto
     secrets:
       NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Before: https://github.com/Parsimotion/long-task-queue-reader/actions/runs/17594314779

After: https://github.com/Parsimotion/long-task-queue-reader/actions/runs/17594522414
